### PR TITLE
fix(ci): update .NET workflow - 9.0.x → 10.0.x with global-json-file

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: ['9.0.x']
+        dotnet-version: ['10.0.x']
 
     steps:
     - uses: actions/checkout@v5
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+        global-json-file: global.json
         
     - name: Restore dependencies
       run: dotnet restore
@@ -48,7 +49,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.x'
+        dotnet-version: '10.0.x'
+        global-json-file: global.json
         
     - name: Restore dependencies
       run: dotnet restore
@@ -79,7 +81,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.x'
+        dotnet-version: '10.0.x'
+        global-json-file: global.json
         
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
## What broke

The `.NET` CI workflow was failing on PRs that update `global.json` (e.g. Renovate's SDK bump PRs).

**Root cause:** The build matrix used `dotnet-version: ['9.0.x']`, but the project now targets .NET 10. When Renovate bumped `global.json` to require SDK `10.0.103`, the runner had:
- `setup-dotnet` installing only 9.0.x
- Pre-installed 10.0.102 on the runner
- `global.json` demanding 10.0.103 → **Not found → CI fails**

Error seen:
```
Requested SDK version: 10.0.103
A compatible .NET SDK was not found.
```

## What was fixed

1. **Updated build matrix** from `'9.0.x'` → `'10.0.x'` (matches project target framework)
2. **Added `global-json-file: global.json`** to all three `setup-dotnet` steps (build, coverage, publish)

With `global-json-file` set, `setup-dotnet` reads `global.json` and **automatically installs** the exact SDK version it requires — so future Renovate SDK bumps will be self-healing (they'll trigger a download of the new SDK version instead of relying on what's pre-installed on the runner).

## Impact

- Fixes the currently failing Renovate PR (`renovate/dotnet-monorepo`)
- Makes all future SDK version updates via Renovate work without CI breakage