### PR TITLE
docs: add CI/CD workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MusicTheory
 
 [![.NET](https://img.shields.io/badge/.NET-9.0-blue)](https://dotnet.microsoft.com/)
+[![Build](https://github.com/phmatray/MusicTheory/actions/workflows/dotnet.yml/badge.svg)](https://github.com/phmatray/MusicTheory/actions/workflows/dotnet.yml)
 [![Tests](https://img.shields.io/badge/tests-504%20passing-brightgreen)](#testing)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
Adds GitHub Actions CI/CD workflow badge to improve visibility of build status.

Shows build status at a glance on the repository homepage.