### PR TITLE
fix(deps): downgrade testing packages to 17.x for xunit.v3 compatibility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
 
     <!-- Testing - Using 17.x line for stable MTP v1 compatibility with xunit.v3 -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
## Summary

- Downgraded `Microsoft.NET.Test.Sdk` from 18.3.0 to 17.14.1
- Downgraded `Microsoft.Testing.Extensions.CodeCoverage` from 18.5.2 to 17.14.2
- Fixes `System.TypeLoadException: Could not load type 'IDataConsumer'` that caused all tests to fail on CI (ubuntu and macos)

## Root cause

xunit.v3 3.2.2 uses Microsoft Testing Platform v1 (`xunit.v3.core.mtp-v1`), while the 18.x versions of `Microsoft.NET.Test.Sdk` and `Microsoft.Testing.Extensions.CodeCoverage` depend on MTP v2 (`Microsoft.Testing.Platform` 2.1.0). The `Microsoft.Testing.Platform.MSBuild` 1.9.1 package tried to call `IDataConsumer` from MTP v2, but xunit only provides the MTP v1 interface, causing the `TypeLoadException` at test runtime.

## Test plan

- [ ] Verify CI passes on all three OS matrix entries (ubuntu, windows, macos)
- [ ] Verify coverage job completes successfully